### PR TITLE
Life

### DIFF
--- a/mrLoadRet/GUI/mlrGetFignum.m
+++ b/mrLoadRet/GUI/mlrGetFignum.m
@@ -27,7 +27,7 @@ else
   else
     % can't figure out fignum
     disp(sprintf('(mlrGetFignum) Could not get a fignum for figure. Returning arbitray value'));
-    round(rand*100);
+    fignum = round(rand*100);
   end
 end
 

--- a/mrLoadRet/GUI/mlrGetFignum.m
+++ b/mrLoadRet/GUI/mlrGetFignum.m
@@ -22,7 +22,7 @@ if isnumeric(h)
   fignum = h;
 else
   % check for number property
-  if isprop(h,'Number')
+  if isprop(h,'Number') && ~isempty(h.Number)
     fignum = h.Number;
   else
     % can't figure out fignum

--- a/mrLoadRet/GUI/mrLoadRetGUI.m
+++ b/mrLoadRet/GUI/mrLoadRetGUI.m
@@ -112,7 +112,7 @@ if ~isempty(viewGet(v,'curBase')) && isequal(1,viewGet(v,'baseMultiAxis'))
   % then get coords
   coords = mlrGetMouseCoords(v);
   if (coords.inAxis ~= -1)
-    set(hObject,'Pointer','fullcrosshair');
+    set(hObject,'Pointer','crosshair');
   else
     set(hObject,'Pointer','arrow');
   end

--- a/mrLoadRet/GUI/mrQuit.m
+++ b/mrLoadRet/GUI/mrQuit.m
@@ -29,7 +29,7 @@ end
 
 mrGlobals;
 
-if strcmp(class(v),'matlab.ui.eventdata.WindowCloseRequestData')
+if ~isempty(v) && strcmp(class(v),'matlab.ui.eventdata.WindowCloseRequestData')
     disp('(mrQuit) v not passed in [CloseRequestData instead]')
     v = [];
 end

--- a/mrLoadRet/GUI/mrQuit.m
+++ b/mrLoadRet/GUI/mrQuit.m
@@ -29,6 +29,11 @@ end
 
 mrGlobals;
 
+if strcmp(class(v),'matlab.ui.eventdata.WindowCloseRequestData')
+    disp('(mrQuit) v not passed in [CloseRequestData instead]')
+    v = [];
+end
+
 % look for the open figure view
 if ieNotDefined('v')
   v = [];

--- a/mrLoadRet/GUI/mrQuit.m
+++ b/mrLoadRet/GUI/mrQuit.m
@@ -68,7 +68,8 @@ if isfield(MLR,'views') && ~isempty(MLR.views)
     view = views{viewNum};
     if isview(view)
       viewCount = viewCount+1;
-      delete(view.figure);
+      delete(view.figure); % deletes object, but apparently we still need
+      closereq;            % a closereq to remove the window in r2014b
     end
   end
   if viewCount > 1

--- a/mrLoadRet/GUI/mrQuit.m
+++ b/mrLoadRet/GUI/mrQuit.m
@@ -35,11 +35,11 @@ if ieNotDefined('v')
   % go through and look for the view with the figure
   if isfield(MLR,'views')
     for i = 1:length(MLR.views)
-      if ~isempty(MLR.views{i}) & isfield(MLR.views{i},'figure') & ~isempty(MLR.views{i}.figure)
+      if ~isempty(MLR.views{i}) && isfield(MLR.views{i},'figure') && ~isempty(MLR.views{i}.figure)
 	if isempty(v)
 	  v = MLR.views{i};
 	else
-	  disp(sprintf('(mrQuit) Multiple open views found. Using last view opened for mrLastView'))
+	  fprintf('(mrQuit) Multiple open views found. Using last view opened for mrLastView')
 	  v = MLR.views{i};
 	end
       end
@@ -47,7 +47,7 @@ if ieNotDefined('v')
   end
 end
 
-if (ieNotDefined('saveMrLastView') || saveMrLastView) && ~isempty(v)
+if (ieNotDefined('saveMrLastView') || mlrGetFignum(saveMrLastView) ) && ~isempty(v)
   mrSaveView(v);
 end
 
@@ -72,7 +72,7 @@ if isfield(MLR,'views') && ~isempty(MLR.views)
     end
   end
   if viewCount > 1
-    disp(sprintf('(mrQuit) Closing %i open views',viewCount));
+    fprintf('(mrQuit) Closing %i open views',viewCount);
   end
   drawnow
   disppercent(-inf,sprintf('(mrQuit) Saving %s',mrDefaultsFilename));

--- a/mrLoadRet/GUI/mrSaveView.m
+++ b/mrLoadRet/GUI/mrSaveView.m
@@ -9,13 +9,13 @@
 function mrSaveView(v)
 
 % remember figure location
-if isprop(v,'Source') && ~isempty(v.Source)
-    mrSetFigLoc('mrLoadRetGUI',v.Source.Position)
-elseif isfield(v,'fignum')
+if isfield(v,'fignum')
     fig = viewGet(v,'fignum');
     if ~isempty(fig)
       mrSetFigLoc('mrLoadRetGUI',get(fig,'Position'));
     end
+elseif isfield(v,'figure') && ~isempty(v.figure)
+    mrSetFigLoc('mrLoadRetGUI',v.figure.Position)
 else
     mrErrorDlg('(mrSaveView) problem saving figure position')
 end
@@ -33,6 +33,10 @@ try
   disppercent(-inf,sprintf('(mrSaveView) Saving %s/mrLastView',homeDir));
         % save the view in the current directory
   view = v;
+  % replace view.figure with figure number (to prevent opening on loading
+  % of the .mat file)
+  view.figure = mlrGetFignum(view);
+  
   if getfield(whos('view'),'bytes')<2e9
     save(fullfile(homeDir,'mrLastView'), 'view','viewSettings', '-V6');
   else

--- a/mrLoadRet/GUI/mrSaveView.m
+++ b/mrLoadRet/GUI/mrSaveView.m
@@ -9,9 +9,15 @@
 function mrSaveView(v)
 
 % remember figure location
-fig = viewGet(v,'fignum');
-if ~isempty(fig)
-  mrSetFigLoc('mrLoadRetGUI',get(fig,'Position'));
+if isprop(v,'Source') && ~isempty(v.Source)
+    mrSetFigLoc('mrLoadRetGUI',v.Source.Position)
+elseif isfield(v,'fignum')
+    fig = viewGet(v,'fignum');
+    if ~isempty(fig)
+      mrSetFigLoc('mrLoadRetGUI',get(fig,'Position'));
+    end
+else
+    mrErrorDlg('(mrSaveView) problem saving figure position')
 end
 
 % remember settings that are not in view

--- a/mrLoadRet/GUI/mrSaveView.m
+++ b/mrLoadRet/GUI/mrSaveView.m
@@ -9,15 +9,17 @@
 function mrSaveView(v)
 
 % remember figure location
-if isfield(v,'fignum')
+try
     fig = viewGet(v,'fignum');
     if ~isempty(fig)
-      mrSetFigLoc('mrLoadRetGUI',get(fig,'Position'));
+          mrSetFigLoc('mrLoadRetGUI',get(fig,'Position'));
     end
-elseif isfield(v,'figure') && ~isempty(v.figure)
-    mrSetFigLoc('mrLoadRetGUI',v.figure.Position)
-else
-    mrErrorDlg('(mrSaveView) problem saving figure position')
+catch
+    if isfield(v,'figure') && ~isempty(v.figure)
+        mrSetFigLoc('mrLoadRetGUI',v.figure.Position)
+    else
+        mrErrorDlg('(mrSaveView) problem saving figure position')
+    end
 end
 
 % remember settings that are not in view

--- a/mrLoadRet/GUI/mrSaveView.m
+++ b/mrLoadRet/GUI/mrSaveView.m
@@ -18,6 +18,8 @@ end
 mrGlobals;
 if isfield(MLR,'panels')
   viewSettings.panels = MLR.panels;
+else
+  viewSettings.panels = [];
 end
 
 homeDir = viewGet(v,'homeDir');
@@ -26,10 +28,10 @@ try
         % save the view in the current directory
   view = v;
   if getfield(whos('view'),'bytes')<2e9
-    eval(sprintf('save %s view viewSettings -V6;',fullfile(homeDir,'mrLastView')));
+    save(fullfile(homeDir,'mrLastView'), 'view','viewSettings', '-V6');
   else
     mrWarnDlg('(mrSaveView) Variable view is more than 2Gb, using option -v7.3 to save');
-    eval(sprintf('save %s view viewSettings -v7.3;',fullfile(homeDir,'mrLastView')));
+    save(fullfile(homeDir,'mrLastView'), 'view', 'viewSettings', '-v7.3');
   end
   % save .mrDefaults in the home directory
   disppercent(inf);


### PR DESCRIPTION
hi justin,

these changes deal with a couple of those numeric/object handle issues. i missed you `mlrGetFignum()` function at first, so started doing logic checks for whether things are objects etc, but rolled those back - that's why the slightly odd commit history and a 'merge' in there.

* once i'd fixed the saving with `mrQuitI()` i then discovered the magic reopening of save figure objects (and incompatibility with pre-r2014b matlab), so change the other functions to strip out that handle object and replace it with a spoofed fignum.

Had a quick look with r2014a to see it works, but haven't checked that `viewGet(v,'fignum')` returns anything sensible, yet. Hope I haven't broken anything unexpected in the process.

ttys, d