### PR TITLE
pRF Fix for Concatenated Datasets

### DIFF
--- a/mrLoadRet/Plugin/pRF/pRFFit.m
+++ b/mrLoadRet/Plugin/pRF/pRFFit.m
@@ -123,7 +123,8 @@ end
 % test to see if scan lengths and stim lengths match
 tf = true;
 for iScan = 1:fit.concatInfo.n
-  if fit.concatInfo.runTransition(iScan,2) ~= size(fitParams.stim{iScan}.im,3)
+  sLength = fit.concatInfo.runTransition(iScan,2) - fit.concatInfo.runTransition(iScan,1) + 1;
+  if sLength ~= size(fitParams.stim{iScan}.im,3)
     mrWarnDlg(sprintf('(pRFFit) Data length of %i for scan %i (concatNum:%i) does not match stimfile length %i',fit.concatInfo.runTransition(iScan,2),scanNum,iScan,size(fitParams.stim{iScan}.im,3)));
     tf = false;
   end


### PR DESCRIPTION
The form of fit.concatInfo.runTransition is:

1 100
101 200
201 300

Where each concatenated scan was length 100. The correct run length (to compare with stim file lengths) is not runTransition(iScan,2), but runTransition(iScan,2)-runTransition(iScan,1)+1.