### PR TITLE
AnatDB ROI check + merge

### DIFF
--- a/mrLoadRet/PluginAlt/mlrAnatDB/mlrAnatDBPlugin.m
+++ b/mrLoadRet/PluginAlt/mlrAnatDB/mlrAnatDBPlugin.m
@@ -183,15 +183,13 @@ function mlrAnatDBMergeCheck(hObject,eventdata)
 % code-snippet to get the view from the hObject variable. 
 v = viewGet(getfield(guidata(hObject),'viewNum'),'view');
 
-disp('(mlrAnatDBMergeCheck) Searching for ROIs that fit standards');
+disp(sprintf('\n\n\n\n\n\n\n\n(mlrAnatDBMergeCheck) Searching for ROIs that fit standards'));
 pfxs = {'l','r'};
-% standards = {'V1','V2','V3','V4','V3a','V3b','V7','LO1','LO2','MT'};
-standards = {'V1'};
+standards = {'V1','V2','V3','V4','V3a','V3b','V7','LO1','LO2','MT'};
 % alternates = {'hV4','hMT+'};
 
 % Check for all l/r ROIs and ask to rename
 roiNames = viewGet(v,'roiNames');
-roiNames = {'lV1','lV2','rV1','rv3a','v3b'};
 if isempty(roiNames)
     disp('(mlrAnatDBMergeCheck) No ROIs to check'); return
 end
@@ -206,8 +204,12 @@ for pi = 1:length(pfxs)
             nofind{end+1} = searchfor;
         elseif found==2
             disp(sprintf('(mlrAnatDBMergeCheck) ROI %s appears to be mislabeled as %s.',searchfor,roiNames{idx}));
+                        nofind{end+1} = searchfor;
+
         elseif found==3               
             disp(sprintf('(mlrAnatDBMergeCheck) You have no ROI: %s, you have %s which is similar...',searchfor,roiNames{idx}));
+                        nofind{end+1} = searchfor;
+
         end
     end
 end
@@ -216,16 +218,25 @@ if ~isempty(nofind)
     disp(sprintf('\n(mlrAnatDBMergeCheck) Please define the missing ROIs.\n\t\t\tYour ROIs may be mis-named.'));
     return
 end
+disp(sprintf('(mlrAnatDBMergeCheck) Found all standards'));
+
 
 % Merge lV1+rV1 into V1, etc...
 for si = 1:length(standards)
     cur = standards{si};
     curL = sprintf('%s%s',pfxs{1},standards{si});
     curR = sprintf('%s%s',pfxs{2},standards{si});
-    [found, ~] = checkROIs(roiNames,standards{si},'','');
+    [found, ~] = checkROIs(roiNames,cur,'','');
+    [foundL, ~] = checkROIs(roiNames,curL,'','');
+    [foundR, ~] = checkROIs(roiNames,curR,'','');
     if ~(found==1)
-        disp(sprintf('(mlrAnatDBMergeCheck) No ROI %s found. Computing the union of %s and %s',cur,curL,curR));
-        v = combineROIs(v,curL,curR,'Union',cur);
+        if foundL&&foundR
+            disp(sprintf('(mlrAnatDBMergeCheck) No ROI %s found. Computing the union of %s and %s',cur,curL,curR));
+            v = combineROIs(v,curL,curR,'Union',cur);
+        else
+            disp('Something went wrong...');
+            keyboard
+        end
     else
         disp(sprintf('(mlrAnatDBMergeCheck) ROI %s already exists, skipping',cur));
     end

--- a/mrLoadRet/PluginAlt/mlrAnatDB/mlrAnatDBPlugin.m
+++ b/mrLoadRet/PluginAlt/mlrAnatDB/mlrAnatDBPlugin.m
@@ -30,6 +30,7 @@ switch action
     mlrAdjustGUI(v,'add','menu','Add ROIs to Anat DB','/File/Anat DB/Add Session to Anat DB','Callback',@mlrAnatDBAddROIs);
     mlrAdjustGUI(v,'add','menu','Add Base Anatomies to Anat DB','/File/Anat DB/Add ROIs to Anat DB','Callback',@mlrAnatDBAddBaseAnatomies);
     mlrAdjustGUI(v,'add','menu','Examine ROI in Anat DB','/File/Anat DB/Add Base Anatomies to Anat DB','Callback',@mlrAnatDBExamineROI,'Separator','on');
+    mlrAdjustGUI(v,'add','menu','Merge and Check ROIs for Anat DB','/File/Anat DB/Examine ROI in Anat DB','Callback',@mlrAnatDBMergeCheck);
 
     % add the callback that will tell mlrAnatDB that a base has been added
     % this is so that we can update the fields that point to the 
@@ -174,6 +175,91 @@ v = viewGet(getfield(guidata(hObject),'viewNum'),'view');
 % put base anatomies into repo
 mlrAnatDBPut(v,v,'mlrBaseAnat');
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%    mlrAnatDBMergeCheck    %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function mlrAnatDBMergeCheck(hObject,eventdata)
+
+% code-snippet to get the view from the hObject variable. 
+v = viewGet(getfield(guidata(hObject),'viewNum'),'view');
+
+disp('(mlrAnatDBMergeCheck) Searching for ROIs that fit standards');
+pfxs = {'l','r'};
+% standards = {'V1','V2','V3','V4','V3a','V3b','V7','LO1','LO2','MT'};
+standards = {'V1'};
+% alternates = {'hV4','hMT+'};
+
+% Check for all l/r ROIs and ask to rename
+roiNames = viewGet(v,'roiNames');
+roiNames = {'lV1','lV2','rV1','rv3a','v3b'};
+if isempty(roiNames)
+    disp('(mlrAnatDBMergeCheck) No ROIs to check'); return
+end
+
+nofind = {};
+for pi = 1:length(pfxs)
+    for si = 1:length(standards)
+        searchfor = sprintf('%s%s',pfxs{pi},standards{si});
+        [found, idx] = checkROIs(roiNames,searchfor,pfxs{pi},standards{si});
+        if found==0
+            disp(sprintf('(mlrAnatDBMergeCheck) You have no ROI: %s',searchfor));
+            nofind{end+1} = searchfor;
+        elseif found==2
+            disp(sprintf('(mlrAnatDBMergeCheck) ROI %s appears to be mislabeled as %s.',searchfor,roiNames{idx}));
+        elseif found==3               
+            disp(sprintf('(mlrAnatDBMergeCheck) You have no ROI: %s, you have %s which is similar...',searchfor,roiNames{idx}));
+        end
+    end
+end
+
+if ~isempty(nofind)
+    disp(sprintf('\n(mlrAnatDBMergeCheck) Please define the missing ROIs.\n\t\t\tYour ROIs may be mis-named.'));
+    return
+end
+
+% Merge lV1+rV1 into V1, etc...
+for si = 1:length(standards)
+    cur = standards{si};
+    curL = sprintf('%s%s',pfxs{1},standards{si});
+    curR = sprintf('%s%s',pfxs{2},standards{si});
+    [found, ~] = checkROIs(roiNames,standards{si},'','');
+    if ~(found==1)
+        disp(sprintf('(mlrAnatDBMergeCheck) No ROI %s found. Computing the union of %s and %s',cur,curL,curR));
+        v = combineROIs(v,curL,curR,'Union',cur);
+    else
+        disp(sprintf('(mlrAnatDBMergeCheck) ROI %s already exists, skipping',cur));
+    end
+end
+%%%%%
+% HELPER FUNCTION TO CHECK FOR ROIS
+%%%%%
+
+function [found, idx] = checkROIs(rois,searchfor,prefix,suffix)
+found = 0;
+idx = -1;
+for ri = 1:length(rois)
+    if strcmp(rois{ri},searchfor)
+        idx = ri; found = 1; return
+    end
+end
+for ri = 1:length(rois)
+    rois{ri} = lower(rois{ri});
+end
+suffix = lower(suffix);
+% didn't find, try to find one that is similar?
+for ri = 1:length(rois)
+    if strcmp(rois{ri},searchfor)
+        found = 3; idx = ri;
+        return
+    end
+    if ~isempty(strfind(rois{ri},suffix))
+        idx = ri; found = 2; 
+        if isempty(strfind(rois{ri},prefix)) || length(rois{ri})~=(length(prefix)+length(suffix))
+            found = 3;
+        end
+        return
+    end
+end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %    mlrAnatDBExamineROI    %

--- a/mrLoadRet/ROI/combineROIs.m
+++ b/mrLoadRet/ROI/combineROIs.m
@@ -63,9 +63,11 @@ roiCoords2 = round(xformROIcoords(roiCoords2,roi2roi,roiVoxelSize2,roiVoxelSize1
 coords1 = roiCoords1';
 coords2 = roiCoords2';
 
+action = lower(action);
+
 % Combine
 switch action
-  case 'Intersection'
+  case 'intersection'
      if isempty(coords1)
        newCoords = coords1;
      elseif isempty(coords2)
@@ -73,7 +75,7 @@ switch action
      else       
        newCoords = intersect(coords1,coords2,'rows');
      end
-  case 'Union'
+  case 'union'
      if isempty(coords1)
        newCoords = coords2;
      elseif isempty(coords2)
@@ -81,7 +83,7 @@ switch action
      else       
        newCoords = union(coords1,coords2,'rows');
      end
-  case 'XOR'
+  case 'xor'
      if isempty(coords1)
        newCoords = coords2;
      elseif isempty(coords2)
@@ -89,7 +91,7 @@ switch action
      else       
        newCoords = setxor(coords1,coords2,'rows');
      end
-  case 'A not B'
+  case 'a not b'
      if isempty(coords1)
        newCoords = coords1;
      elseif isempty(coords2)


### PR DESCRIPTION
Adds functionality to the AnatDB plugin to check that standard ROIs exist and are named correctly (V1->V4, V3a/b, V7, LO1-LO2, MT). Then merges all l/r hemisphere ROIs.