### PR TITLE
Reverse prf code

### DIFF
--- a/mrAlign/mrAlign.m
+++ b/mrAlign/mrAlign.m
@@ -67,7 +67,7 @@ ALIGN.ignoreZeroVoxels = 1;      % specifies if zero voxels should be ignored wh
 ALIGN.displayAlignmentSteps = 1; % specifies if alignment optimization steps are displayed
 
 ALIGN.minCoarseVoxelSize = 3;    % minimum size of inplanes/volume voxels to compute coarse alignment
-ALIGN.minFineVoxelSize = 1;      % minimum size of inplanes voxels to compute fine alignment
+ALIGN.minFineVoxelSize = .5;      % minimum size of inplanes voxels to compute fine alignment
 ALIGN.minEPICoarseVoxelSize = 2; % minimum size of inplanes/volume voxels to compute coarse EPI alignment
 ALIGN.minEPIFineVoxelSize = .5;  % minimum size of inplanes voxels to compute fine EPI alignment
 

--- a/mrLoadRet/PluginAlt/mlrAnatDB/mlrAnatDBPlugin.m
+++ b/mrLoadRet/PluginAlt/mlrAnatDB/mlrAnatDBPlugin.m
@@ -265,7 +265,7 @@ v = mrLoadRet;
 scan2magTo = viewGet(v,'scan2mag');
 
 scan2scan = inv(scan2magFrom) * scan2magTo;
-
+analysis = viewGet(v,'analysis');
 toDims = viewGet(v,'scandims');
 [x,y,z] = ind2sub(toDims,1:(toDims(1)*toDims(2)*toDims(3)));
 out = scan2scan*[x;y;z;ones(size(x))];
@@ -274,10 +274,11 @@ for ci = 1:length(cOverlays)
     dat = cOverlays(ci).data{3};
     lOverlay = interp3(dat,out(2,:),out(1,:),out(3,:),'nearest');
     lOverlaydat = reshape(lOverlay,toDims);
-    v = mrDispOverlay(lOverlaydat,1,viewGet(v,'analysis'),v,sprintf('overlayName=%s',cOverlays(ci).name));
+    v = mrDispOverlay(lOverlaydat,1,analysis,v,sprintf('overlayName=%s',cOverlays(ci).name));
 end
 
 refreshMLRDisplay(viewGet(v,'viewNum'));
+saveAnalysis(v,analysis.name);
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %    mlrAnatDBReversepRF    %

--- a/mrLoadRet/PluginAlt/mlrAnatDB/mlrAnatDBPlugin.m
+++ b/mrLoadRet/PluginAlt/mlrAnatDB/mlrAnatDBPlugin.m
@@ -31,6 +31,9 @@ switch action
     mlrAdjustGUI(v,'add','menu','Add Base Anatomies to Anat DB','/File/Anat DB/Add ROIs to Anat DB','Callback',@mlrAnatDBAddBaseAnatomies);
     mlrAdjustGUI(v,'add','menu','Examine ROI in Anat DB','/File/Anat DB/Add Base Anatomies to Anat DB','Callback',@mlrAnatDBExamineROI,'Separator','on');
     mlrAdjustGUI(v,'add','menu','Merge and Check ROIs for Anat DB','/File/Anat DB/Examine ROI in Anat DB','Callback',@mlrAnatDBMergeCheck);
+    mlrAdjustGUI(v,'add','menu','Reverse pRF','/File/Anat DB/Merge and Check ROIs for Anat DB','Callback',@mlrAnatDBReversepRF,'Separator','on');
+    mlrAdjustGUI(v,'add','menu','Get Reversed pRF','/File/Anat DB/Reverse pRF','Callback',@mlrAnatDBgetReversedpRF);
+
 
     % add the callback that will tell mlrAnatDB that a base has been added
     % this is so that we can update the fields that point to the 
@@ -176,6 +179,180 @@ v = viewGet(getfield(guidata(hObject),'viewNum'),'view');
 mlrAnatDBPut(v,v,'mlrBaseAnat');
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%    mlrAnatDBgetReversedpRF    %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function mlrAnatDBgetReversedpRF(hObject,eventdata)
+
+v = viewGet(getfield(guidata(hObject),'viewNum'),'view');
+
+stop = 1;
+
+% go load 
+% get subjectID
+subjectID = mlrAnatDBSubjectID(v);
+
+% everything went ok, switch directories and start up over there
+[localRepo, localRepoLargeFiles] = mlrAnatDBGetRepo(subjectID);
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%    mlrAnatDBReversepRF    %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function mlrAnatDBReversepRF(hObject,eventdata)
+
+v = viewGet(getfield(guidata(hObject),'viewNum'),'view');
+
+% find pRF analysis
+opts = [];
+chosen = -1;
+while chosen == -1 || isempty(chosen)
+    for i = 1:length(v.analyses)
+        cAnal = v.analyses{i};
+        disp(sprintf('Analysis %i: %s',i,cAnal.name));
+        if strfind(cAnal.name,'pRF')
+            chosen = i;
+        end
+        opts = [opts i];
+    end
+    chosen = input('Which analysis do you want to pick? Choose one by typing in the number: ');
+end
+
+analysis = v.analyses{i};
+
+% define stimulus range
+polar = [];
+while isempty(polar)
+    resp = input('Is your input in polar [p] or cartesian [c] coordinates? ','s');
+    if strcmpi(resp,'p')
+        polar = 1;
+        warning('Polar angle coordinates are not implemented');
+        return
+    elseif strcmpi(resp,'c')
+        polar = 0;
+    end
+end
+
+knownAnalyses = {'cohcon'};
+knownCoords = {{[3.5 12 -7 7],[-12 -3.5 -7 7]}};
+knownNames = {{'Right','Left'}};
+knownStr = knownAnalyses{1};
+for ki = 2:length(knownAnalyses)
+    knownStr = [knownStr,', ',knownAnalyses{ki}];
+end
+
+anName = '';
+names = '';
+if ~polar
+    resp = [];
+    while ~iscell(resp)
+        resp = input(sprintf('Input your stimulus as a cell.\nEach cell is an array with x0,x1,y0,y1 defining a rectangular space.\nYou can also input %s.\n',knownStr));
+        
+        for ki = 1:length(knownAnalyses)
+            if strcmp(resp,knownAnalyses{ki})
+                disp(sprintf('You requested the %s stimulus.',knownAnalyses{ki}));
+                resp = knownCoords{ki};
+                anName = knownAnalyses{ki};
+                names = knownNames{ki};
+            end
+        end
+        if any(cellfun(@(x) length(x)~=4,resp))
+            disp('Badly conditioned responses, each array should be length 4');
+            resp = [];
+        end
+    end
+    stimulusCoords = resp;
+else
+    warning('Implement me!');
+end
+
+if isempty(anName)
+    anName = input('Please input the name of your experiment (e.g. cohcon)\n','s');
+end
+
+dims = viewGet(v,'scandims');
+total = dims(1)*dims(2)*dims(3);
+
+% figureo out where in analysis.overlays the data is stored
+whichDim = 0;
+for i = 1:length(analysis.overlays(1).data)
+    if isequal(dims,size(analysis.overlays(1).data{i}))
+        whichDim = i;
+    end
+end
+
+data.r2 = analysis.overlays(1).data{whichDim};
+data.pa = analysis.overlays(2).data{whichDim};
+data.ecc = analysis.overlays(3).data{whichDim};
+data.std = analysis.overlays(4).data{whichDim};
+
+% f = figure;
+stimulusOverlap = zeros(dims(1),dims(2),dims(3),length(stimulusCoords));
+disppercent(-inf,sprintf('Computing %i voxels...',total));
+count = 0;
+for x = 1:dims(1)
+    for y = 1:dims(2)
+        for z = 1:dims(3)
+            stimulusOverlap(x,y,z,:) = computeOverlap(data,stimulusCoords,x,y,z,0);
+            count = count+1;
+            disppercent(count/total);
+        end
+    end
+end
+disppercent(inf);
+
+if isempty(names)
+    warning('implement me!');
+    keyboard
+end
+
+[v, analysis] = mrDispOverlay(stimulusOverlap(:,:,:,1),viewGet(v,'curscan'),analysis,v,sprintf('overlayName=%sOverlap%s',names{1},anName));
+[v, analysis] = mrDispOverlay(stimulusOverlap(:,:,:,2),viewGet(v,'curscan'),analysis,v,sprintf('overlayName=%sOverlap%s',names{2},anName));
+
+refreshMLRDisplay(viewGet(v,'viewNum'));
+
+function overlap = computeOverlap(data,stimulusCoords,x,y,z,f)
+
+% helper function for mlrAnatDBReversepRF
+
+pa = data.pa(x,y,z);
+ecc = data.ecc(x,y,z);
+std = data.std(x,y,z);
+
+if isnan(pa) || isnan(ecc) || (std <= 0)
+    overlap = nan;
+    return
+else
+    [cx,cy] = pol2cart(pa,ecc);
+end
+
+p = zeros(1,length(stimulusCoords));
+for i = 1:length(stimulusCoords)
+    sc = stimulusCoords{i};
+    p(i) = mvncdf([sc(1) sc(3)],[sc(2) sc(4)],[cx,cy],[std 0;0 std]);
+end
+
+%%
+if f>0
+    figure(f)
+    clf
+    [sfx, sfy] = meshgrid(-20:20,-20:20);
+
+    % out = gauss([1 cx cy std std 0 0],mfx,mfy);
+    outs = gauss([1 cx cy std std 0 0],sfx,sfy);
+
+    figure
+    imagesc(sfx(1,:),sfy(:,1),outs);
+    hold on
+    rectangle('Position',[stimulusCoords{1}(1) stimulusCoords{1}(3) stimulusCoords{1}(2)-stimulusCoords{1}(1) stimulusCoords{1}(4)-stimulusCoords{1}(3)]);
+    rectangle('Position',[stimulusCoords{2}(1) stimulusCoords{2}(3) stimulusCoords{2}(2)-stimulusCoords{2}(1) stimulusCoords{1}(4)-stimulusCoords{1}(3)]);
+
+    title(sprintf('Left %0.3f Right %0.3f',p(2),p(1)));
+end
+
+overlap = p;
+
+%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %    mlrAnatDBMergeCheck    %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function mlrAnatDBMergeCheck(hObject,eventdata)
@@ -271,6 +448,8 @@ for ri = 1:length(rois)
         return
     end
 end
+
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %    mlrAnatDBExamineROI    %

--- a/mrLoadRet/PluginAlt/mlrAnatDB/mlrAnatDBPlugin.m
+++ b/mrLoadRet/PluginAlt/mlrAnatDB/mlrAnatDBPlugin.m
@@ -192,7 +192,7 @@ subjectID = mlrAnatDBSubjectID(v);
 
 % pull repos, note we need the large file repo (unfortunately), because
 % otherwise we don't have access to the pRF analysis
-[localRepo, localRepoLargeFiles] = mlrAnatDBGetRepo(subjectID);
+[~, localRepoLargeFiles] = mlrAnatDBGetRepo(subjectID);
 
 % try to find the pRF analysis automatically
 pRFloc = '';
@@ -208,6 +208,9 @@ else
     pRFloc = fullfile(localRepoLargeFiles,'localizers',localizers(1).name);
 end
 
+if strcmp(questdlg(sprintf('(mlrAnatDBPlugin) Before you run this make sure you selected the analysis and scan you want the new overlays to be added to!!!'),'mlrAnatDBPlugin','Ok','Cancel','Cancel'),'Cancel')
+  return
+end
 if strcmp(questdlg(sprintf('(mlrAnatDBPlugin) I need to close your current session while I load the overlays from the pRF session. Is that okay?'),'mlrAnatDBPlugin','Ok','Cancel','Cancel'),'Cancel')
   return
 end
@@ -217,7 +220,13 @@ mrQuit;
 cd(pRFloc);
 
 v = newView();
-questdlg('Please pick the analysis you want to load overlays from.','Choose Analysis','OK');
+if strcmp(questdlg(sprintf('(mlrAnatDBPlugin) Please pick the analysis you want to load overlays from.'),'mlrAnatDBPlugin','Ok','Cancel','Cancel'),'Cancel')
+    mrQuit
+    mrQuit(0);
+    cd(curpwd)
+    mrLoadRet;
+    return
+end
 v = loadAnalysis(v);
 overlays = v.analyses{1}.overlays;
 
@@ -269,7 +278,6 @@ for ci = 1:length(cOverlays)
 end
 
 refreshMLRDisplay(viewGet(v,'viewNum'));
-stop = 1;
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %    mlrAnatDBReversepRF    %

--- a/mrLoadRet/PluginAlt/mlrAnatDB/mlrAnatDBPlugin.m
+++ b/mrLoadRet/PluginAlt/mlrAnatDB/mlrAnatDBPlugin.m
@@ -255,8 +255,20 @@ v = mrLoadRet;
 % transform cOverlays into the current scan space
 scan2magTo = viewGet(v,'scan2mag');
 
-scan2scan = inv(scan2magTo) * scan2magFrom;
+scan2scan = inv(scan2magFrom) * scan2magTo;
 
+toDims = viewGet(v,'scandims');
+[x,y,z] = ind2sub(toDims,1:(toDims(1)*toDims(2)*toDims(3)));
+out = scan2scan*[x;y;z;ones(size(x))];
+lOverlays = {};
+for ci = 1:length(cOverlays)
+    dat = cOverlays(ci).data{3};
+    lOverlay = interp3(dat,out(2,:),out(1,:),out(3,:),'nearest');
+    lOverlaydat = reshape(lOverlay,toDims);
+    v = mrDispOverlay(lOverlaydat,1,viewGet(v,'analysis'),v,sprintf('overlayName=%s',cOverlays(ci).name));
+end
+
+refreshMLRDisplay(viewGet(v,'viewNum'));
 stop = 1;
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Merging the reverse pRF code into the master branch. Adds two functions to the AnatDB core code that allow you to “reverse” a pRF while in a retinotopy session, and to “get” the reversed pRF and move it into a task session.

Code is fully functional for rectangular stimuli. Still needs code written for non-rectangular stimuli.