### PR TITLE
Changeset fixing the interrogator when ROIs are visible on a surface

### DIFF
--- a/mrLoadRet/GUI/mlrGetMouseCoords.m
+++ b/mrLoadRet/GUI/mlrGetMouseCoords.m
@@ -110,17 +110,23 @@ else
   if all(pointerLoc(1,:) >= 0)
     % then use select3d which is slooow, but accurate
     if isfield(MLR.interrogator{viewNum},'axesnum')
-      hobj = get(MLR.interrogator{viewNum}.axesnum,'Children');
+      if verLessThan('matlab','8.4')
+        hobj = get(MLR.interrogator{viewNum}.axesnum,'Children');
+        hobj = hobj(end);
       % make sure we are using the correct object (should be the 3D
       % brain). Use end here because with searchForVoxel we plot a
       % point on the image and the brain object always seems to be
       % last. But if this is not always the case, then we may need
       % to do a little more work here to find the correct object
-      [pos vertex vertexIndex] = select3d(hobj(end));
+      else %from  matlab version 8.5a, the handle to the base has been 
+        %stored in the view, so use that
+        hobj = viewGet(v,'baseHandle');
+      end
+      [pos vertex vertexIndex] = select3d(hobj);
       % convert the index to the coordinates
       if ~isempty(pos)
 	baseCoordMap = viewGet(v,'baseCoordMap');
-	%we'll take the coordinates of the middle of whatever range of cortical depth is currenlty selected
+	%we'll take the coordinates of the middle of whatever range of cortical depth is currently selected
 	corticalSlice = max(1,ceil(mean(viewGet(v,'corticalDepth'))*size(baseCoordMap.coords,5)));
 	pos = round(squeeze(baseCoordMap.coords(1,vertexIndex,1,:,corticalSlice)));
 	%pos = round(squeeze(baseCoordMap.coords(1,vertexIndex,1,:)));

--- a/mrLoadRet/GUI/mrInterrogator.m
+++ b/mrLoadRet/GUI/mrInterrogator.m
@@ -359,28 +359,30 @@ end
 % section here, remove the endHandler section which unlinks this handler.
 if ~verLessThan('matlab','8.4') && (viewGet(v,'baseType') == 2)
   % get the handle for the patch
-  h = viewGet(v,'baseHandle');
-  if ~isempty(h)
-    % set the first in the list - note that there may be more if 
+  hBase = viewGet(v,'baseHandle');
+  hROI = viewGet(v,'surfaceROIHandle');
+  for h = [hBase hROI]
+    % set the first base in the list - note that there may be more if 
     % we are displaying multiple bases at once, but for now we ignore
     % all those "alt bases" and just respond to clicks on the main base
-    set(h,'ButtonDownFcn',@mrInterrogatorSurfaceCallback);
+    set(h,'ButtonDownFcn',{@mrInterrogatorSurfaceCallback,hBase});
     % set the viewNum in the handles
     userData = get(h,'UserData');
     userData.viewNum = viewNum;
     set(h,'UserData',userData);
-    v = viewSet(v,'baseHandle',h);
   end
-  % set the other callbacks
-  set(fignum,'WindowButtonMotionFcn',sprintf('mrInterrogator(''mouseMove'',%i)',viewNum));
-  set(fignum,'WindowButtonUpFcn',sprintf('mrInterrogator(''mouseUp'',%i)',viewNum));
+  if ~isempty(hBase)  
+    v = viewSet(v,'baseHandle',hBase);
+  end
+  if ~isempty(hROI)  
+    v = viewSet(v,'surfaceROIHandle',hROI);
+  end
 else
-  
-  % set the callbacks appropriately
-  set(fignum,'WindowButtonMotionFcn',sprintf('mrInterrogator(''mouseMove'',%i)',viewNum));
   set(fignum,'WindowButtonDownFcn',sprintf('mrInterrogator(''mouseDown'',%i)',viewNum));
-  set(fignum,'WindowButtonUpFcn',sprintf('mrInterrogator(''mouseUp'',%i)',viewNum));
 end
+% set the other callbacks
+set(fignum,'WindowButtonMotionFcn',sprintf('mrInterrogator(''mouseMove'',%i)',viewNum));
+set(fignum,'WindowButtonUpFcn',sprintf('mrInterrogator(''mouseUp'',%i)',viewNum));
 
 % set pointer to crosshairs
 MLR.interrogator{viewNum}.pointer = get(fignum,'pointer');
@@ -553,8 +555,9 @@ end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function mrInterrogatorSurfaceCallback(hObject,e,handles,varargin)
 
-% get viewNum
-userData = get(hObject,'UserData');
+% get viewNum from the surface base handle (even if called from another surface,
+% which might be a surface ROI.
+userData = get(handles,'UserData');
 % if no viewNum set then, something is wrong
 % since this should have been set when mrInterrogator was initialized
 % so giveup
@@ -568,13 +571,13 @@ click.viewNum = userData.viewNum;
 % to replace the broken select3d
 % get the point that the user clicked
 click.pos = e.IntersectionPoint;
-% compute distance to every vertex and pick the vertex that is closest to the intersectoin point
+% compute distance to every vertex and pick the vertex that is closest to the intersection point
 [minDist click.vertexIndex] = min(sum((e.Source.Vertices-repmat(click.pos',1,size(e.Source.Vertices,1))').^2,2));
 % now get the vertex position
 click.vertex = e.Source.Vertices(click.vertexIndex,:);
 
 % set the user data to include this latest click information
-set(hObject,'UserData',click);
+set(handles,'UserData',click);
 
 % call mouse down - note that the handler will get the click location
 % because we have stored in the userdata for the surface. This

--- a/mrLoadRet/View/viewGet.m
+++ b/mrLoadRet/View/viewGet.m
@@ -1481,6 +1481,17 @@ switch lower(param)
       % set to empty if handle is stale 
       if ~ishandle(val),val = [];end
     end
+  case {'surfaceroihandle'}
+    % basedata = viewGet(view,'baseHandle',[baseNum])
+    b = getBaseNum(view,varargin);
+    n = viewGet(view,'numberofbasevolumes');
+    if b & (b > 0) & (b <= n)
+      if isfield(view.baseVolumes(b),'hROI')
+        val = view.baseVolumes(b).hROI;
+      end
+      % set to empty if handle is stale 
+      if ~ishandle(val),val = [];end
+    end
   case {'basehdr'}
     % basedata = viewGet(view,'basehdr',[baseNum])
     b = getBaseNum(view,varargin);

--- a/mrLoadRet/View/viewSet.m
+++ b/mrLoadRet/View/viewSet.m
@@ -1146,7 +1146,15 @@ switch lower(param)
     if ~isempty(baseNum) & ~isempty(view.baseVolumes)
       view.baseVolumes(baseNum).h = h;
     end
-
+    
+case{'surfaceroihandle'}
+    % view = viewSet(view,'baseHandle',h,[baseNum]);
+    h = val;
+    baseNum = getBaseNum(view,varargin);
+    if ~isempty(baseNum) & ~isempty(view.baseVolumes)
+      view.baseVolumes(baseNum).hROI = h;
+    end
+   
  case{'basemultidisplay'}
     % view = viewSet(view,'baseMultiDisplay',multiDisplay,[baseNum]);
     baseNum = getBaseNum(view,varargin);


### PR DESCRIPTION
There is a problem with using interrogator functions on surface ROIs (issue  #52).  
I tried fixing it, and I think it works, but I might not have fixed it in the most elegant way. 
I think the problem occurs only for Matlab version >=8.5a, in which select3d is broken and
the coordinates of the click are stored in the surface base handle, to be retrieved by select3d as a special case. The bug is due to the fact that the callback associated with the base surface (mrInterrogatorSurfaceCallback) cannot be called when clicking on an ROI because the base surface is hidden by the surface ROIs. In order to fix this, all surface ROI handles are now saved in view.baseVolumes.hROI (in refreshMLRDisplay). For this, I had to create new viewSet and viewGet cases for surface ROI handles (copied from the 'baseHandle' case). When mrInterrogator initializes, the mrInterrogatorSurfaceCallback is associated not only with the base surface but with all the ROI surfaces that are displayed, so that it is called when the user clicks on any of these surfaces. Then the callback saves the current click coordinates in the base surface handle and these can be retrieved later by mlrGetMouseCoords.m (through select3d).
I also had to fix which surface object is used by mlrGetMouseCoords, since there are several of them when ROIs are displayed and the base surface is not always the last one as it was assumed.