### PR TITLE
Adding feature to save ROI prf params when you add roi to anatdb

### DIFF
--- a/mrLoadRet/PluginAlt/mlrAnatDB/mlrAnatDBPut.m
+++ b/mrLoadRet/PluginAlt/mlrAnatDB/mlrAnatDBPut.m
@@ -685,6 +685,26 @@ for iRoi = roiList
     % set that the ROI is created from this session
     v = viewSet(v,'roiBranchNum',branchNum+1,iRoi);
   end
+  % Add the pRF Params if they exist
+  if ~isfield(roi, 'pRFparams')  || isempty(roi.pRFparams)
+    % Check if there is a pRF analysis loaded
+    analysis = viewGet(v, 'analysis');
+    if ~isempty(analysis) && strcmp(analysis.type, 'pRFAnal')
+      % if so, extract the pRF params for this roi
+      d = viewGet(v, 'd');
+      [scanCoords scan2roi] = getROICoordinates(v,iRoi);
+      linScanCoords = sub2ind(viewGet(v, 'scanDims'), scanCoords(1,:), scanCoords(2,:), scanCoords(3,:));
+      [~,idx] = ismember(linScanCoords, d.linearCoords); % 
+      idx = idx(idx~=0);
+      roipRFparams = [d.params(:, idx); d.r(idx)']; % 4 x nVoxels
+      
+      % and call viewSet to set the "roipRFparams" field of the roi
+      val = {}; val{1} = roipRFparams;
+      val{2} = viewGet(v, 'scan2roi');
+      v = viewSet(v, 'roipRFparams', val, iRoi);
+    end
+  end
+  
   % save it  
   filePath{end+1} = saveROI(v,iRoi,false);
   % set the .mat extension

--- a/mrLoadRet/View/isroi.m
+++ b/mrLoadRet/View/isroi.m
@@ -34,11 +34,13 @@ if (nargout == 2)
 		    'createdFromSession','';
 		    'branchNum',[];
 		    'subjectID',[];
+        'pRFparams', [];
+        'scan2roi', [];
 		   };
 else
   % Return 0 if the overlay structure is missing any fields required or
   % optional (since w/out changing the analysis structure it is invalid).
-  requiredFields = {'color','coords','date','name','viewType','voxelSize','xform','sformCode','vol2mag','vol2tal','createdBy','createdOnBase','displayOnBase','createdFromSession','branchNum','subjectID'};
+  requiredFields = {'color','coords','date','name','viewType','voxelSize','xform','sformCode','vol2mag','vol2tal','createdBy','createdOnBase','displayOnBase','createdFromSession','branchNum','subjectID', 'pRFparams', 'scan2roi'};
   optionalFields = {};
 end
 

--- a/mrLoadRet/View/viewSet.m
+++ b/mrLoadRet/View/viewSet.m
@@ -23,7 +23,7 @@ function [view tf] = viewSet(view,param,val,varargin)
 % view = viewSet(view,'basemin',number,[baseNum]);
 % view = viewSet(view,'basemax',number,[baseNum]);
 %
-% view = viewSet(view,'newanalysis',analysisStructure);
+% view = viewSet(view,'newanalysis',analysisStructure); 
 % view = viewSet(view,'deleteAnalysis',analysisNum);
 % view = viewSet(view,'currentAnalysis',analysisNum);
 %
@@ -2243,7 +2243,21 @@ switch lower(param)
     if ~isempty(roiNum)
       view.ROIs(roiNum).createdOnBase = val;
     end
-
+    
+ case {'roiprfparams'}
+    % v = viewSet(v,'roiCreatedOnBase',baseName,[roiNum]);
+    % sets the created on base field of roi
+    curRoi = viewGet(view,'currentRoi');
+    if ~isempty(varargin)
+      roiNum = varargin{1};
+    else
+      roiNum = curRoi;
+    end
+    if ~isempty(roiNum)
+      view.ROIs(roiNum).pRFparams = val{1}; % x y 
+      view.ROIs(roiNum).scan2roi = val{2};
+    end
+    
  case {'roicreatedfromsession'}
     % v = viewSet(v,'roiCreatedFromSession',sessionName,[roiNum]);
     % sets the created from session field in roi
@@ -2493,7 +2507,7 @@ switch lower(param)
 	MLR.callbacks{2}{end+1} = {varargin{1}};
       end
     end
-	
+	    
  otherwise
    mrWarnDlg(sprintf('(viewSet) Unknown parameter %s',param));
 end


### PR DESCRIPTION
1. Modified mlrAnatDBPut to check if a pRF analysis exists in the current view and if so, to add the pRF params to the roi struct (using viewSet) before adding the ROI to anatdb
2. Modified viewSet by adding a "roiprfparams" options which adds the pRF params as well as the scan2roi transform to the specified ROI.
3. Modified isroi to add pRFparams and scan2roi as optional fields.