### PR TITLE
mlrnum2str.m: fix nanmax not exist problem in 2023b or later

### DIFF
--- a/mrUtilities/MatlabUtilities/mlrnum2str.m
+++ b/mrUtilities/MatlabUtilities/mlrnum2str.m
@@ -64,7 +64,11 @@ if length(size(num))>2
 elseif length(size(num)) == 2
   num = num';
   % compute maxnumdigits on the left side of decimal excluding inf and nan
-  maxnumdigits = length(sprintf('%i',floor(nanmax(abs(num(~isinf(num(:))))))));
+  if exist('nanmax') %#ok<EXIST> new version of MATLAB does not have function nanmax
+    maxnumdigits = length(sprintf('%i',floor(nanmax(abs(num(~isinf(num(:))))))));
+  else
+    maxnumdigits = length(sprintf('%i',floor(max(abs(num(~isinf(num(:)))),[],1,'omitnan'))));
+  end
   % if there is an inf or nan, account for that
   if any(isnan(num(:))) | any(isinf(num(:)))
     % if sigfigs is zero then Inf and Nan cannot line up with decimal, so shift over by a space


### PR DESCRIPTION
nanmax was removed in MATLAB R2023b. This fix checks whether nanmax 
exists and falls back to max(..., 'omitnan') for newer MATLAB versions,
which also maintains backwards compatibility with older versions (eg. 2019b).